### PR TITLE
Fix nerd font installation

### DIFF
--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -285,8 +285,8 @@ install_docker() {
 
 install_nerd_fonts() {
   log "Install Nerd Fonts"
-  git clone --filter=blob:none --sparse git@github.com:ryanoasis/nerd-fonts
-  cd nerd-fonts
+  git clone --filter=blob:none --sparse https://github.com/ryanoasis/nerd-fonts.git
+  cd nerd-fonts || return
   git sparse-checkout add patched-fonts/JetBrainsMono
   bash install.sh JetBrainsMono
   cd .. && rm -rf nerd-fonts


### PR DESCRIPTION
Install example from nerd fonts documentation offers to use ssh to clone repo. But setup script do not suppose to automatically generate and add ssh key to github account. So ssh was replaced by http.