### PR TITLE
Fix sdkman installation

### DIFF
--- a/ubuntu/setup.sh
+++ b/ubuntu/setup.sh
@@ -30,8 +30,8 @@ update_distro() {
     log_error "Update distro is failure."
     exit 1
   }
-  # Required by homebrew during installation.
-  sudo apt-get -y install build-essential curl
+  sudo apt-get -y install build-essential curl # Required by homebrew.
+  sudo apt-get -y install zip unzip            # Required by sdkman.
 }
 
 install_drivers() {

--- a/utils.sh
+++ b/utils.sh
@@ -104,8 +104,6 @@ install_required_cli() {
   brew install -q \
     git \
     cmake \
-    unzip \
-    zip \
     procps \
     file
 }


### PR DESCRIPTION
(ubuntu): unzip installed from homebrew conflicts with bin from apt-get install. macos already have such bin in /bin dir.